### PR TITLE
Fix warning in PyTest raises.

### DIFF
--- a/tests/test_vi/test_analytical_kl_loss.py
+++ b/tests/test_vi/test_analytical_kl_loss.py
@@ -619,7 +619,7 @@ def test_init(
                 f" {var_dist.__class__.__name__}.",
             ),
             (ValueError, "Provided model is not bayesian."),
-            (UnsupportedDistributionError, ""),
+            (UnsupportedDistributionError, "UniformPrior does not support use as predictive distribution"),
         ]
         error, message = error_list[expected_error]
         with pytest.raises(error, match=message):


### PR DESCRIPTION
This fixes the following warning against comparing against an empty string in PyTest `raises`:
```
=================================================== warnings summary ===================================================
tests/test_vi/test_analytical_kl_loss.py::test_init[prior20-var_dist20-predictive_distribution20-None-None-NormalNormalDivergence-None-None-None-False-3]
  /opt/homebrew/Caskroom/miniconda/base/envs/joss_torch_blue/lib/python3.14/site-packages/_pytest/raises.py:622: PytestWarning: matching against an empty string will *always* pass. If you want to check for an empty message you need to pass '^$'. If you don't want to match you should pass `None` or leave out the parameter.
    super().__init__(match=match, check=check)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 215 passed, 1 warning in 5.41s ============================================