### PR TITLE
Extend tests to consider NormalVarDist epsilon and NB sign shift

### DIFF
--- a/tests/test_vi/test_distributions/test_non_bayesian.py
+++ b/tests/test_vi/test_distributions/test_non_bayesian.py
@@ -100,7 +100,7 @@ class TestNonBayesian:
             raise
 
         target_mean = samples.mean(dim=0)
-        target_loss = target()(target_mean, reference)
+        target_loss = -target()(target_mean, reference)
 
         assert target_mean.shape == predictive_mean.shape
         assert predictive_mean.device == device

--- a/torch_blue/vi/distributions/non_bayesian.py
+++ b/torch_blue/vi/distributions/non_bayesian.py
@@ -137,7 +137,8 @@ class NonBayesian(Distribution):
         """
         Calculate the loss of the mean prediction with respect to reference.
 
-        This is not affected by :data:`_globals._USE_NORM_CONSTANTS`.
+        Since the loss works on NEGATIVE log likelihood this is minus the specified
+        loss. This is not affected by :data:`_globals._USE_NORM_CONSTANTS`.
 
         Parameters
         ----------
@@ -154,7 +155,7 @@ class NonBayesian(Distribution):
         """
         if self.loss is None:
             raise ValueError("loss_type must be set during initialization")
-        return self.loss(parameters, reference)
+        return -self.loss(parameters, reference)
 
 
 class UniformPrior(NonBayesian):


### PR DESCRIPTION
Extend test to check for the use of epsilon in the variational log prob calculation.
Fix assumed error, where non-Bayesian log prob should return the negative loss to compensate KL-loss sign