### PR TITLE
Feature/initialization fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "ruff",
     "mypy",
     "pytest",
+    "pytest-rerunfailures",
     "coverage",
     "build",
 ]
@@ -152,4 +153,4 @@ filterwarnings = [
 
 [tool.coverage.run]
 source = ["torch_blue"]
-command_line = "-m pytest"
+command_line = "-m pytest --reruns 1"

--- a/tests/test_vi/test_utils/test_convert.py
+++ b/tests/test_vi/test_utils/test_convert.py
@@ -153,11 +153,12 @@ def test_keep_weights(module: nn.Module, n_args: int) -> None:
         sample.append(torch.randn(2, 3, 5))
 
     ref = module(*sample)
+    module1 = deepcopy(module)
     convert_to_vimodule(
-        module, variational_distribution=NonBayesian(), keep_weights=True
+        module1, variational_distribution=NonBayesian(), keep_weights=True
     )
 
-    out = module(*sample)
+    out = module1(*sample)
     if isinstance(ref, tuple):
         assert torch.allclose(ref[0], out[0])
         assert torch.allclose(ref[1], out[1])

--- a/tests/test_vi/test_utils/test_convert.py
+++ b/tests/test_vi/test_utils/test_convert.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 
 import pytest
@@ -11,37 +12,39 @@ from torch_blue.vi.utils import convert
 
 
 class BiasOnlyModule(nn.Module):
+    """Dummy class to test fan-in with only 1d parameters."""
+
     def __init__(self, dim: int) -> None:
         super().__init__()
 
         self.bias = nn.Parameter(torch.zeros(dim))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass."""
         return x + self.bias
 
 
 class NestedModule(nn.Module):
+    """Dummy module to test conversion of more complex custom structures."""
+
     def __init__(self, dim: int) -> None:
         super().__init__()
 
         self.sequence = nn.Sequential(
             BiasOnlyModule(dim),
             nn.Linear(dim, dim),
-            nn.Sequential(
-                nn.Linear(dim, dim),
-                nn.Linear(dim, dim)
-            )
+            nn.Sequential(nn.Linear(dim, dim), nn.Linear(dim, dim)),
         )
 
-        self.modulelist = nn.ModuleList([
-            BiasOnlyModule(dim),
-            nn.Sequential(
-                nn.Linear(dim, dim),
-                nn.Linear(dim, dim)
-            )
-        ])
+        self.modulelist = nn.ModuleList(
+            [
+                BiasOnlyModule(dim),
+                nn.Sequential(nn.Linear(dim, dim), nn.Linear(dim, dim)),
+            ]
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass."""
         x = self.sequence(x)
         for module in self.modulelist:
             x = x + module(x)
@@ -50,30 +53,47 @@ class NestedModule(nn.Module):
 
 
 @pytest.mark.parametrize(
-    "module,n_args,custom_module",
+    "module,n_args",
     [
-        (nn.Linear(5, 6, bias=True), 1, False),
-        (nn.Linear(5, 6, bias=False), 1, False),
-        (nn.MultiheadAttention(5, 1), 3, False),
-        (nn.Transformer(5, 1, 1, 1, 5), 2, False),
-        (BiasOnlyModule(5), 1, True),
-        (NestedModule(5), 1, True),
+        (nn.Linear(5, 6, bias=True), 1),
+        (nn.Linear(5, 6, bias=False), 1),
+        (nn.MultiheadAttention(5, 1), 3),
+        (nn.Transformer(5, 1, 1, 1, 5), 2),
+        (BiasOnlyModule(5), 1),
+        (NestedModule(5), 1),
     ],
 )
-def test_convert_to_vimodule(module: nn.Module, n_args: int, custom_module: bool) -> None:
+def test_convert_to_vimodule(module: nn.Module, n_args: int) -> None:
     """Test autoconversion to vi module."""
     sample = []
     for _ in range(n_args):
         sample.append(torch.randn(2, 3, 5))
 
     module1 = deepcopy(module)
-    convert_to_vimodule(module1)
+    custom_module = not hasattr(nn, module.__class__.__name__)
+
+    if not custom_module:
+        convert_to_vimodule(module1)
+    else:
+        with pytest.warns(
+            UserWarning,
+            match="only one-dimensional Parameters where found, assuming fan_in to be 1",
+        ):
+            convert_to_vimodule(module1)
+        warnings.filterwarnings(
+            "ignore",
+            message="only one-dimensional Parameters where found, assuming fan_in to be 1",
+        )
+
     if custom_module:
-        ref_class = getattr(torch_blue.vi.utils.convert, "AVI" + module.__class__.__name__)
-        assert ref_class == module1.__class__
+        ref_class = getattr(
+            torch_blue.vi.utils.convert, "AVI" + module.__class__.__name__
+        )
     else:
         ref_class = getattr(torch_blue.vi, "VI" + module.__class__.__name__)
-        assert ref_class == type(module1)
+
+    assert module1.__class__ == type(module1)
+    assert ref_class == type(module1)
 
     module1(*sample)
 
@@ -81,16 +101,12 @@ def test_convert_to_vimodule(module: nn.Module, n_args: int, custom_module: bool
     module1.return_log_probs = False
     module1(*sample)
 
-    if custom_module:
-        module2 = deepcopy(module)
-        convert_to_vimodule(module2)
-        module2(*sample)
-    else:
-        convert.ban_convert(module.__class__, ban_mode="replace")
-        module2 = deepcopy(module)
-        convert_to_vimodule(module2)
-        assert ref_class != type(module2)
-        module2(*sample)
+    convert.ban_convert(module.__class__, ban_mode="replace")
+    module2 = deepcopy(module)
+    convert_to_vimodule(module2)
+    # custom modules should be unaffected by replace ban
+    assert (ref_class == type(module2)) == custom_module
+    module2(*sample)
 
     module3 = deepcopy(module)
     convert_to_vimodule(module3)
@@ -110,6 +126,15 @@ def test_convert_to_vimodule(module: nn.Module, n_args: int, custom_module: bool
     convert_to_vimodule(module9)
     assert type(module9) == type(module)
     convert.ban_convert(module.__class__, unban=True)
+
+    warnings.resetwarnings()
+
+
+def test_invalid_ban_mode_error() -> None:
+    """Test error for when ban mode is invalid."""
+    invalid_mode = "error"
+    with pytest.raises(ValueError, match=f"Unknown ban mode: {invalid_mode}"):
+        convert.ban_convert(nn.Linear, ban_mode=invalid_mode)
 
 
 @pytest.mark.parametrize(
@@ -179,20 +204,24 @@ def test_ban_convert(ban_norms: bool) -> None:
         assert module not in convert._blacklist
 
 
-def test_ban_submodule():
+def test_ban_submodule() -> None:
     """Test adding and removing modules from submodule blacklist."""
     module = NestedModule(5)
     sample = torch.randn(2, 3, 5)
 
+    warnings.filterwarnings(
+        "ignore",
+        message="only one-dimensional Parameters where found, assuming fan_in to be 1",
+    )
     module1 = deepcopy(module)
     convert_to_vimodule(module1)
-    module1(sample)
 
     module2 = deepcopy(module)
     convert.ban_convert(module.__class__, ban_mode="ban")
     convert_to_vimodule(module2)
     module2(sample)
     assert module1.sequence.__class__ == module2.sequence.__class__
+    convert.ban_convert(module.__class__, ban_mode="ban", unban=True)
 
     module3 = deepcopy(module)
     convert.ban_convert(module.__class__, ban_mode="submodule")
@@ -200,13 +229,14 @@ def test_ban_submodule():
     module3(sample)
     assert module1.sequence.__class__ != module3.sequence.__class__
     assert module.sequence.__class__ == module3.sequence.__class__
+    convert.ban_convert(module.__class__, ban_mode="submodule", unban=True)
 
     module4 = deepcopy(module)
-    convert.ban_convert(module.__class__, ban_mode="ban", unban=True)
-    convert.ban_convert(module.__class__, ban_mode="submodule", unban=True)
     convert_to_vimodule(module4)
     assert module1.sequence.__class__ == module4.sequence.__class__
     assert module1.__class__ == module4.__class__
+
+    warnings.resetwarnings()
 
 
 @pytest.mark.parametrize("mode", ["replace", "reuse"])

--- a/tests/test_vi/test_utils/test_convert.py
+++ b/tests/test_vi/test_utils/test_convert.py
@@ -10,6 +10,15 @@ from torch_blue.vi.distributions import MeanFieldNormal, NonBayesian, StudentT
 from torch_blue.vi.utils import convert
 
 
+class BiasOnlyModule(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+
+        self.bias = nn.Parameter(torch.zeros(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.bias
+
 @pytest.mark.parametrize(
     "module,n_args",
     [
@@ -17,6 +26,7 @@ from torch_blue.vi.utils import convert
         (nn.Linear(5, 6, bias=False), 1),
         (nn.MultiheadAttention(5, 1), 3),
         (nn.Transformer(5, 1, 1, 1, 5), 2),
+        (BiasOnlyModule(5), 1)
     ],
 )
 def test_convert_to_vimodule(module: nn.Module, n_args: int) -> None:

--- a/tests/test_vi/test_utils/test_convert.py
+++ b/tests/test_vi/test_utils/test_convert.py
@@ -19,17 +19,48 @@ class BiasOnlyModule(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x + self.bias
 
+
+class NestedModule(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+
+        self.sequence = nn.Sequential(
+            BiasOnlyModule(dim),
+            nn.Linear(dim, dim),
+            nn.Sequential(
+                nn.Linear(dim, dim),
+                nn.Linear(dim, dim)
+            )
+        )
+
+        self.modulelist = nn.ModuleList([
+            BiasOnlyModule(dim),
+            nn.Sequential(
+                nn.Linear(dim, dim),
+                nn.Linear(dim, dim)
+            )
+        ])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.sequence(x)
+        for module in self.modulelist:
+            x = x + module(x)
+
+        return x
+
+
 @pytest.mark.parametrize(
-    "module,n_args",
+    "module,n_args,custom_module",
     [
-        (nn.Linear(5, 6, bias=True), 1),
-        (nn.Linear(5, 6, bias=False), 1),
-        (nn.MultiheadAttention(5, 1), 3),
-        (nn.Transformer(5, 1, 1, 1, 5), 2),
-        (BiasOnlyModule(5), 1)
+        (nn.Linear(5, 6, bias=True), 1, False),
+        (nn.Linear(5, 6, bias=False), 1, False),
+        (nn.MultiheadAttention(5, 1), 3, False),
+        (nn.Transformer(5, 1, 1, 1, 5), 2, False),
+        (BiasOnlyModule(5), 1, True),
+        (NestedModule(5), 1, True),
     ],
 )
-def test_convert_to_vimodule(module: nn.Module, n_args: int) -> None:
+def test_convert_to_vimodule(module: nn.Module, n_args: int, custom_module: bool) -> None:
     """Test autoconversion to vi module."""
     sample = []
     for _ in range(n_args):
@@ -37,19 +68,29 @@ def test_convert_to_vimodule(module: nn.Module, n_args: int) -> None:
 
     module1 = deepcopy(module)
     convert_to_vimodule(module1)
-    ref_class = getattr(torch_blue.vi, "VI" + module.__class__.__name__)
-    assert ref_class == type(module1)
+    if custom_module:
+        ref_class = getattr(torch_blue.vi.utils.convert, "AVI" + module.__class__.__name__)
+        assert ref_class == module1.__class__
+    else:
+        ref_class = getattr(torch_blue.vi, "VI" + module.__class__.__name__)
+        assert ref_class == type(module1)
+
     module1(*sample)
 
     # Test no log prob mode
     module1.return_log_probs = False
     module1(*sample)
 
-    convert.ban_convert(module.__class__, ban_mode="replace")
-    module2 = deepcopy(module)
-    convert_to_vimodule(module2)
-    assert ref_class != type(module2)
-    module2(*sample)
+    if custom_module:
+        module2 = deepcopy(module)
+        convert_to_vimodule(module2)
+        module2(*sample)
+    else:
+        convert.ban_convert(module.__class__, ban_mode="replace")
+        module2 = deepcopy(module)
+        convert_to_vimodule(module2)
+        assert ref_class != type(module2)
+        module2(*sample)
 
     module3 = deepcopy(module)
     convert_to_vimodule(module3)
@@ -136,6 +177,36 @@ def test_ban_convert(ban_norms: bool) -> None:
     convert.ban_convert(module_list, unban=True)
     for module in module_list:
         assert module not in convert._blacklist
+
+
+def test_ban_submodule():
+    """Test adding and removing modules from submodule blacklist."""
+    module = NestedModule(5)
+    sample = torch.randn(2, 3, 5)
+
+    module1 = deepcopy(module)
+    convert_to_vimodule(module1)
+    module1(sample)
+
+    module2 = deepcopy(module)
+    convert.ban_convert(module.__class__, ban_mode="ban")
+    convert_to_vimodule(module2)
+    module2(sample)
+    assert module1.sequence.__class__ == module2.sequence.__class__
+
+    module3 = deepcopy(module)
+    convert.ban_convert(module.__class__, ban_mode="submodule")
+    convert_to_vimodule(module3)
+    module3(sample)
+    assert module1.sequence.__class__ != module3.sequence.__class__
+    assert module.sequence.__class__ == module3.sequence.__class__
+
+    module4 = deepcopy(module)
+    convert.ban_convert(module.__class__, ban_mode="ban", unban=True)
+    convert.ban_convert(module.__class__, ban_mode="submodule", unban=True)
+    convert_to_vimodule(module4)
+    assert module1.sequence.__class__ == module4.sequence.__class__
+    assert module1.__class__ == module4.__class__
 
 
 @pytest.mark.parametrize("mode", ["replace", "reuse"])

--- a/torch_blue/vi/base.py
+++ b/torch_blue/vi/base.py
@@ -1,6 +1,6 @@
+import warnings
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, cast
-import warnings
 
 import torch
 from torch import Tensor
@@ -570,13 +570,11 @@ class VIModule(Module, metaclass=PostInitCallMeta):
             loop = checked_dict = variable_shapes  # type:ignore[assignment]
 
         all_none = True
-
         for var in cast(Tuple[str, ...], loop):
             if checked_dict[var] is None:
                 continue
 
             all_none = False
-
             if variable_shapes is None:
                 weight_name = self.variational_parameter_name(
                     var,
@@ -591,10 +589,11 @@ class VIModule(Module, metaclass=PostInitCallMeta):
 
             fan_in, _ = init._calculate_fan_in_and_fan_out(shape_dummy)
             return fan_in
-        else:
-            if all_none:
-                raise NoVariablesError("All module variables are set to None.")
-            else:
-                warnings.warn("only one-dimensional Parameters where found, assuming fan_in to be 1")
-                return 1
 
+        if all_none:
+            raise NoVariablesError("All module variables are set to None.")
+        else:
+            warnings.warn(
+                "only one-dimensional Parameters where found, assuming fan_in to be 1"
+            )
+            return 1

--- a/torch_blue/vi/base.py
+++ b/torch_blue/vi/base.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, cast
+import warnings
 
 import torch
 from torch import Tensor
@@ -568,6 +569,10 @@ class VIModule(Module, metaclass=PostInitCallMeta):
         else:
             loop = checked_dict = variable_shapes  # type:ignore[assignment]
 
+        if len(loop) == 0:
+            raise NoVariablesError("All module variables are set to None.")
+
+
         for var in cast(Tuple[str, ...], loop):
             if checked_dict[var] is None:
                 continue
@@ -580,7 +585,13 @@ class VIModule(Module, metaclass=PostInitCallMeta):
                 shape_dummy = getattr(self, weight_name)
             else:
                 shape_dummy = torch.zeros(variable_shapes[var])
+
+            if shape_dummy.dim() < 2:
+                continue
+
             fan_in, _ = init._calculate_fan_in_and_fan_out(shape_dummy)
             return fan_in
+        else:
+            warnings.warn("only one-dimensional Parameters where found, assuming fan_in to be 1")
+            return 1
 
-        raise NoVariablesError("All module variables are set to None.")

--- a/torch_blue/vi/base.py
+++ b/torch_blue/vi/base.py
@@ -569,13 +569,13 @@ class VIModule(Module, metaclass=PostInitCallMeta):
         else:
             loop = checked_dict = variable_shapes  # type:ignore[assignment]
 
-        if len(loop) == 0:
-            raise NoVariablesError("All module variables are set to None.")
-
+        all_none = True
 
         for var in cast(Tuple[str, ...], loop):
             if checked_dict[var] is None:
                 continue
+
+            all_none = False
 
             if variable_shapes is None:
                 weight_name = self.variational_parameter_name(
@@ -592,6 +592,9 @@ class VIModule(Module, metaclass=PostInitCallMeta):
             fan_in, _ = init._calculate_fan_in_and_fan_out(shape_dummy)
             return fan_in
         else:
-            warnings.warn("only one-dimensional Parameters where found, assuming fan_in to be 1")
-            return 1
+            if all_none:
+                raise NoVariablesError("All module variables are set to None.")
+            else:
+                warnings.warn("only one-dimensional Parameters where found, assuming fan_in to be 1")
+                return 1
 


### PR DESCRIPTION
- added a module with only a single dimension parameter to autoconvert tests
- modify the VIModule._calculate_fan_in method to make it be able to handle the aforementioned type of module (including a warning for a potentially ill-defined fan_in)
- add a test for the ban_mode="submodule" mode of convert.ban_convert