### PR TITLE
Fix deepcopy functionality of VIReturn

### DIFF
--- a/tests/test_vi/test_utils/test_vi_return.py
+++ b/tests/test_vi/test_utils/test_vi_return.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Tuple, cast
 
 import pytest
@@ -35,6 +36,21 @@ class TestVIReturn:
         shape = tuple(torch.randint(1, 10, [3]))
         vi_return, ref_tensor, ref_log_probs = self._init_instance(shape, lp_is_none)
         new = vi_return.clone()
+        assert new is not vi_return
+        assert torch.all(ref_tensor == new)
+
+        if lp_is_none:
+            assert new.log_probs is None
+        else:
+            assert new.log_probs is not vi_return.log_probs
+            assert torch.all(new.log_probs == ref_log_probs)
+
+    @pytest.mark.parametrize("lp_is_none", [True, False])
+    def test_deepcopy(self, lp_is_none: bool) -> None:
+        """Test deepcopy compatibility."""
+        shape = tuple(torch.randint(1, 10, [3]))
+        vi_return, ref_tensor, ref_log_probs = self._init_instance(shape, lp_is_none)
+        new = deepcopy(vi_return)
         assert new is not vi_return
         assert torch.all(ref_tensor == new)
 

--- a/torch_blue/vi/utils/vi_return.py
+++ b/torch_blue/vi/utils/vi_return.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from torch import Tensor
 
@@ -28,6 +28,10 @@ class VIReturn(Tensor):
     def __init__(self, data: Tensor, log_probs: Optional[Tensor]) -> None:
         super().__init__()
         self.log_probs = log_probs
+
+    def new_empty(self, size: Tuple[int, ...], **kwargs: Any) -> "VIReturn":
+        """Return a VIReturn of size `size` filled with uninitialized data."""
+        return self.__class__(super().new_empty(size, **kwargs), None)
 
     # The doc strings of this and the next method throw warnings. This is inherited
     # from pytorch, but seems to compile correctly.


### PR DESCRIPTION
Add new_empty method to VIReturn to make it function with deepcopy.