### PR TITLE
Fix/dataset size error

### DIFF
--- a/tests/test_vi/test_analytical_kl_loss.py
+++ b/tests/test_vi/test_analytical_kl_loss.py
@@ -765,10 +765,17 @@ def test_forward(
         output = model(sample, samples=samples)
 
         if init_dataset_size is None and fwrd_dataset_size is None:
-            message = f"No dataset_size is provided. Batch size \\({batch_size}\\) is used instead."
-            with pytest.warns(UserWarning, match=message):
-                analytical_loss = criterion(output, target, fwrd_dataset_size)
+            with pytest.raises(
+                ValueError,
+                match="dataset_size must be provided",
+            ):
+                criterion(output, target, fwrd_dataset_size)
             ref_loss = ref_criterion(output, target, batch_size)
+            # Skip the rest of this iteration since forward raised
+            model.zero_grad()
+            ref_loss.backward()
+            optimizer.step()
+            continue
         else:
             analytical_loss = criterion(output, target, fwrd_dataset_size)
             ref_loss = ref_criterion(output, target, fwrd_dataset_size)

--- a/tests/test_vi/test_kl_loss.py
+++ b/tests/test_vi/test_kl_loss.py
@@ -1,7 +1,5 @@
-from warnings import filterwarnings
-
 import torch
-from pytest import raises, warns
+from pytest import raises
 
 from torch_blue.vi import KullbackLeiblerLoss, VIReturn
 from torch_blue.vi.distributions import MeanFieldNormal, UniformPrior
@@ -28,9 +26,9 @@ def test_kl_loss(device: torch.device) -> None:
         _ = KullbackLeiblerLoss(UniformPrior())
 
     loss1 = KullbackLeiblerLoss(MeanFieldNormal())
-    with warns(
-        UserWarning,
-        match=f"No dataset_size is provided. Batch size \({batch_size}\) is used instead.",
+    with raises(
+        ValueError,
+        match="dataset_size must be provided",
     ):
         _ = loss1(model_return, target)
 
@@ -66,11 +64,6 @@ def test_kl_loss(device: torch.device) -> None:
     out5 = loss4(model_return, target)
     assert out1 != out5
     assert out5.device == device
-
-    filterwarnings("ignore", category=UserWarning)
-    out6 = loss1(model_return, target)
-    assert out1 == out6
-    assert out6.device == device
 
     loss5 = KullbackLeiblerLoss(MeanFieldNormal(), dataset_size=batch_size, track=True)
 

--- a/torch_blue/vi/analytical_kl_loss.py
+++ b/torch_blue/vi/analytical_kl_loss.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from math import log
 from typing import Callable, Dict, Iterable, List, Optional, Type, Union
-from warnings import warn
 
 import torch
 from torch import Tensor
@@ -457,13 +456,12 @@ class AnalyticalKullbackLeiblerLoss(Module):
         samples = model_output
 
         if (dataset_size is None) and (self.dataset_size is None):
-            warn(
-                f"No dataset_size is provided. Batch size ({samples.shape[1]}) is used"
-                f" instead."
+            raise ValueError(
+                "dataset_size must be provided either in the constructor or in the "
+                "forward method. It is required to correctly balance the data fitting "
+                "and prior matching terms of the ELBO loss."
             )
-            n_data = samples.shape[1]
-        else:
-            n_data = dataset_size or self.dataset_size
+        n_data = dataset_size or self.dataset_size
 
         prior_matching = self.heat * self.prior_matching()
         # Sample average for predictive log prob is already done

--- a/torch_blue/vi/kl_loss.py
+++ b/torch_blue/vi/kl_loss.py
@@ -1,5 +1,4 @@
 from typing import Dict, List, Optional, cast
-from warnings import warn
 
 from torch import Tensor
 from torch.nn import Module
@@ -119,12 +118,12 @@ class KullbackLeiblerLoss(Module):
         mean_log_probs = log_probs.mean(dim=0) if log_probs.dim() != 1 else log_probs
 
         if (dataset_size is None) and (self.dataset_size is None):
-            warn(
-                f"No dataset_size is provided. Batch size ({samples.shape[1]}) is used instead."
+            raise ValueError(
+                "dataset_size must be provided either in the constructor or in the "
+                "forward method. It is required to correctly balance the data fitting "
+                "and prior matching terms of the ELBO loss."
             )
-            n_data = samples.shape[1]
-        else:
-            n_data = dataset_size or self.dataset_size
+        n_data = dataset_size or self.dataset_size
 
         prior_matching = self.heat * (mean_log_probs[1] - mean_log_probs[0])
         # Sample average for predictive log prob is already done


### PR DESCRIPTION
Closes #22

The KL loss functions (`KullbackLeiblerLoss` and `AnalyticalKullbackLeiblerLoss`) previously issued a warning and inferred `dataset_size` from the batch dimension when not provided. This behavior is unreliable. 

This PR replaces that fallback with a `ValueError` requiring the user to provide `dataset_size` either in the constructor or in the `forward` call.

Changes:
- `torch_blue/vi/kl_loss.py`: warning → ValueError
- `torch_blue/vi/analytical_kl_loss.py`: same change
- Updated tests to expect ValueError instead of UserWarning
