### PR TITLE
Assert categorical target is integer type (#45)

### DIFF
--- a/tests/test_vi/test_distributions/test_categorical.py
+++ b/tests/test_vi/test_distributions/test_categorical.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_blue.vi.distributions import Categorical
@@ -43,3 +44,22 @@ def test_categorical(device: torch.device) -> None:
     assert torch.allclose(log_prob2, target_log_prob2)
     assert log_prob1.device == device
     assert log_prob2.device == device
+
+
+def test_categorical_float_target_raises(device: torch.device) -> None:
+    """Test that Categorical raises TypeError for float targets."""
+    predictive_dist = Categorical()
+
+    batch = 3
+    categories = 5
+    probs = torch.rand((batch, categories), device=device)
+    float_target = torch.tensor([0.0, 1.0, 2.0], device=device)
+
+    with pytest.raises(TypeError, match="Categorical target must be of integer type"):
+        predictive_dist.log_prob_from_parameters(float_target, probs)
+
+    # Verify integer targets still work fine
+    int_target = torch.tensor([0, 1, 2], device=device)
+    result = predictive_dist.log_prob_from_parameters(int_target, probs)
+    assert result.shape == (batch,)
+    assert result.device == device

--- a/torch_blue/vi/distributions/categorical.py
+++ b/torch_blue/vi/distributions/categorical.py
@@ -95,6 +95,11 @@ class Categorical(Distribution):
             The log probability of the label under the predicted class probabilities.
             Shape: (1,).
         """
+        if reference.is_floating_point():
+            raise TypeError(
+                f"Categorical target must be of integer type, got {reference.dtype}. "
+                "Targets should be class indices such as 0, 1, 2,... ."
+            )
         parameters = torch.log(parameters + eps)
         value = reference.long().unsqueeze(-1)
         value, log_pmf = torch.broadcast_tensors(value, parameters)


### PR DESCRIPTION
Closes #45

`Categorical.log_prob_from_parameters` previously called `reference.long()` which silently converted float targets to integers via truncation. This could hide bugs where users accidentally pass float targets.

This PR adds a `TypeError` if `reference` is a floating point tensor, with a clear message directing users to pass integer class indices.

Changes:
- `torch_blue/vi/distributions/categorical.py`: raise TypeError for float targets
- `tests/test_vi/test_distributions/test_categorical.py`: test for the new error + verify integer targets still work
